### PR TITLE
[confiscan] Write errors and warnings to stderr

### DIFF
--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -33,7 +33,7 @@ REPLY=""
 MAKE_TAR=0
 
 error() {
-    printf '%b' "${BRED}Error: ${DEFAULT}${1}\n"
+    printf '%b' "${BRED}Error: ${DEFAULT}${1}\n" >&2
     exit "${2}"
 }
 

--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -38,7 +38,7 @@ error() {
 }
 
 warn() {
-    printf '%b' "${BYELLOW}Warning: ${DEFAULT}${1}\n"
+    printf '%b' "${BYELLOW}Warning: ${DEFAULT}${1}\n" >&2
 }
 
 info() {


### PR DESCRIPTION
This commit makes sure errors are actually written to stderr, where they belong ;)