### PR TITLE
[confiscan] Fix mount points output

### DIFF
--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -261,6 +261,8 @@ while read -r line; do
             "${output_dir}/mount_points.csv"
 done < /proc/mounts
 
+column -t -s, "${output_dir}/mount_points.csv"
+
 [[ ${MAKE_TAR} -eq 1 ]] && {
     info "Creating tarball..."
     tar -cvf "${output_dir}.tar.gz" "${output_dir}" &> /dev/null && \


### PR DESCRIPTION
All mount points were collected but not shown to the user when running the script. This commit addresses this problem.