### PR TITLE
[confiscan] Gather APT repo sources

### DIFF
--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -161,6 +161,14 @@ done < <(dpkg-query -Wf '${Package} ${Version} ${Architecture} ${Source}\n')
 info "Packages found on the system:"
 column -t -s, "${output_dir}/packages.csv"
 
+[[ -f /etc/apt/sources.list ]] || error "No sources.list file found." 2
+[[ -d /etc/apt/sources.list.d ]] || error "No sources.list.d directory found." 2
+
+info "Package repositories:"
+grep -E '^[a-zA-Z]' /etc/apt/sources.list /etc/apt/sources.list.d/* 2> /dev/null | \
+    sed 's/^[^:]*://' | \
+    tee "${output_dir}/repositories.txt"
+
 ###########
 # Network #
 ###########


### PR DESCRIPTION
Not only the installed packages are good to know, also the possible repositories used by APT to install them are important. Therefore, getting a copy of the `sources.list` file, and all other files from the `sources.list.d` directory is important.