### PR TITLE
[confiscan] Fix APT sources failure

### DIFF
--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -167,7 +167,7 @@ column -t -s, "${output_dir}/packages.csv"
 info "Package repositories:"
 grep -E '^[a-zA-Z]' /etc/apt/sources.list /etc/apt/sources.list.d/* 2> /dev/null | \
     sed 's/^[^:]*://' | \
-    tee "${output_dir}/repositories.txt"
+    tee "${output_dir}/repositories.txt" || :
 
 ###########
 # Network #


### PR DESCRIPTION
Since commit 2e288b2, the script fails when no files are present in `/etc/apt/sources.list.d/`, this commit addresses this issue.