### PR TITLE
[confiscan] Fix broken links after copy and show enabled systemd units

### DIFF
--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -425,7 +425,11 @@ for c in "${APP_CONFIGS[@]}"; do
         error "${c} no such file or directory." 2
 
     mkdir -p "${output_dir}/$(dirname "${c}")"
-    cp -r "${c}" "${output_dir}/$(dirname "${c}")"
+
+    # Use rsync to fix issues when copying symbolic links.
+    # `--copy-links` will copy the actual file instead of the link.
+    # `|| :` will prevent the script from exiting when broken symbolic links are found.
+    rsync --force --archive --recursive --copy-links "${c}" "${output_dir}/$(dirname "${c}")" || :
 done
 
 # File Integrity Check of original files, excluding ./original.sha256

--- a/src/tool/confiscan.sh
+++ b/src/tool/confiscan.sh
@@ -404,6 +404,8 @@ printf 'Unit,State,Preset\n' > "${output_dir}/systemd_enabled_units.csv"
 systemctl list-unit-files --state=enabled --no-legend | \
     sed 's/ \{1,\}/,/g' >> "${output_dir}/systemd_enabled_units.csv"
 
+column -t -s, "${output_dir}/systemd_enabled_units.csv"
+
 [[ -d "/etc/systemd/system/" ]] && APP_CONFIGS+=("/etc/systemd/system/")
 [[ -d "/etc/systemd/user/" ]] && APP_CONFIGS+=("/etc/systemd/user/")
 [[ -d "/usr/lib/systemd/system/" ]] && APP_CONFIGS+=("/usr/lib/systemd/system/")


### PR DESCRIPTION
This commit addresses a problem related to copying symlinks. When a symbolic link was copied, and it pointed to a location not present in the specified config paths, it will break the link,
making it unavailable in the inventory. With `rsync` we can follow these pointers and copy the actual file.